### PR TITLE
Fix build failure due to missing semicolon

### DIFF
--- a/conf.y
+++ b/conf.y
@@ -128,7 +128,7 @@ match_block: match_block match_block_statement
            | match_block_statement
 
 match_block_statement: /* empty */
-           | "pattern" ':' QUOTEDSTRING { conf_new_match_pattern(conf, $3) }
+           | "pattern" ':' QUOTEDSTRING { conf_new_match_pattern(conf, $3); }
            | "reaction" ':' QUOTEDSTRING { CURMATCH.reaction = $3; }
            | "reaction" ':' "none" { CURMATCH.no_reaction = 1; }
            | "shell" ':' QUOTEDSTRING { CURMATCH.shell = $3; }


### PR DESCRIPTION
Fixes:
```
conf.y:132:87: error: expected ';' after expression
                                        { conf_new_match_pattern(conf, (yyvsp[0].str)) }
                                                                                      ^
                                                                                      ;
```